### PR TITLE
In order to make file extensions on attachment searchable. The field sea...

### DIFF
--- a/PowerSlice/ContentSliceBase.cs
+++ b/PowerSlice/ContentSliceBase.cs
@@ -104,6 +104,8 @@ namespace PowerSlice
             return searchRequest.For(searchPhrase)
                                 .InField(x => ((IContent) x).Name, 2)
                                 .InField(x => ((IContent)x).SearchText())
+                                .InField(x => ((IContentMedia)x).SearchFileExtension())
+                                .Include(x => ((IContentMedia)x).SearchFileExtension().PrefixCaseInsensitive(searchPhrase), 1.5)
                                 .Include(x => ((IContent)x).Name.PrefixCaseInsensitive(searchPhrase), 1.5)
                                 .Include(x => ((IContent)x).Name.AnyWordBeginsWith(searchPhrase));
         }


### PR DESCRIPTION
...rchfileextension is added for the search and it is set to search in using prefixcaseinsensitive.