### PR TITLE
Remove redundant order property

### DIFF
--- a/PowerSlice/ContentSliceBase.cs
+++ b/PowerSlice/ContentSliceBase.cs
@@ -116,11 +116,6 @@ namespace PowerSlice
                                 .Include(x => ((IContent)x).Name.AnyWordBeginsWith(searchPhrase));
         }
 
-        public virtual int Order
-        {
-            get { return 0; }
-        }
-
         public virtual IEnumerable<CreateOption> CreateOptions
         {
             get { return null; }

--- a/PowerSlice/IContentSlice.cs
+++ b/PowerSlice/IContentSlice.cs
@@ -5,7 +5,6 @@ namespace PowerSlice
 {
     public interface IContentSlice : IContentQuery
     {
-        int Order { get; }
         IEnumerable<CreateOption> CreateOptions { get; }
     }
 }


### PR DESCRIPTION
Despite what the most [detailed documentation says](https://world.episerver.com/articles/Items/re-introducing-powerslice-for-episerver-cms/), overriding the `Order` property does not change the UI order at all.

In fact, you need to override SortOrder (see the [SliceComponent](https://github.com/episerver/PowerSlice/blob/master/PowerSlice/SlicesComponent.cs) which applies this ordering).

This also aligns with developer expectations elsewhere (e.g. tasks), therefore, I think it makes sense to remove the unused `Order` to avoid confusion...which is what this PR does.